### PR TITLE
Feature/rep deprecated xml

### DIFF
--- a/default/app.conf
+++ b/default/app.conf
@@ -14,5 +14,5 @@ label = Apteligent
 [launcher]
 author = Apteligent
 description = Retrieve and search Apteligent mobile app performance data from published API.  Provide sample dashboards. Provide support for Splunk 6.0+
-version = 1.3.7
+version = 1.3.9
 

--- a/default/data/ui/views/crashsearch.xml
+++ b/default/data/ui/views/crashsearch.xml
@@ -26,7 +26,6 @@
         </searchString>
         <option name="drilldown">none</option>
         <option name="underLabel">unique crashes found in this time period</option>
-        <option name="linkView">search</option>
       </single>
 
       <single>
@@ -36,7 +35,6 @@
         </searchString>
         <option name="drilldown">none</option>
         <option name="underLabel">total crashes found in this time period</option>
-        <option name="linkView">search</option>
       </single>
 
   </row>


### PR DESCRIPTION
The "linkView" attribute has been deprecated. Also, it is only used to specify a drilldown destination OTHER THAN "search", so I'm not sure why it was here to begin with.

@alexanderyoung PTAL